### PR TITLE
Add a link to user edit function

### DIFF
--- a/app/assets/stylesheets/_menu.scss
+++ b/app/assets/stylesheets/_menu.scss
@@ -16,6 +16,9 @@
     i{
       float: right;
     }
+    .fa-white{
+      color: #FFFFFF;
+    }
   }
 
   .menu__content{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
   protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -1,6 +1,5 @@
 class ChatController < ApplicationController
   def index
     @user = current_user
-    redirect_to(new_user_session_path) unless user_signed_in?
   end
 end

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -1,5 +1,6 @@
 class ChatController < ApplicationController
   def index
-    @user = current_user.name
+    @user = current_user
+    redirect_to(new_user_session_path) unless user_signed_in?
   end
 end

--- a/app/controllers/chat_controller.rb
+++ b/app/controllers/chat_controller.rb
@@ -1,4 +1,5 @@
 class ChatController < ApplicationController
   def index
+    @user = current_user.name
   end
 end

--- a/app/views/chat/index.html.haml
+++ b/app/views/chat/index.html.haml
@@ -2,7 +2,7 @@
 
   %div.menu
     %div.menu__title
-      %h2 ryosukemaehira
+      %h2 #{@user}
       = icon('pencil-square-o', class: 'fa-2x')
       = link_to (edit_user_registration_path method: :get) do
         %i{class:"fa fa-cog fa-2x fa-white"}

--- a/app/views/chat/index.html.haml
+++ b/app/views/chat/index.html.haml
@@ -4,7 +4,8 @@
     %div.menu__title
       %h2 ryosukemaehira
       = icon('pencil-square-o', class: 'fa-2x')
-      = icon('cog', class: 'fa-2x')
+      = link_to (edit_user_registration_path method: :get) do
+        %i{class:"fa fa-cog fa-2x fa-white"}
 
     %div.menu__content
       %div.group

--- a/app/views/chat/index.html.haml
+++ b/app/views/chat/index.html.haml
@@ -2,7 +2,7 @@
 
   %div.menu
     %div.menu__title
-      %h2 #{@user}
+      %h2 #{@user.name}
       = icon('pencil-square-o', class: 'fa-2x')
       = link_to (edit_user_registration_path method: :get) do
         %i{class:"fa fa-cog fa-2x fa-white"}


### PR DESCRIPTION
# WHY
Add the function to edit user's information in the chat display

# WHAT
- Add a link to user edit function in the chat display
- Add user name in the chat display
- Make user redirect to sign in display unless user sign in
[![https://gyazo.com/320aaf6b499f29ff9c2ee1c8180facb8](https://i.gyazo.com/320aaf6b499f29ff9c2ee1c8180facb8.png)](https://gyazo.com/320aaf6b499f29ff9c2ee1c8180facb8)